### PR TITLE
Enable the option to deploy an SUSE SSSD Client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ shared-data/
 !shared-data/README
 shared-enrollment/
 !shared-enrollment/README
+*.retry

--- a/provision.sh
+++ b/provision.sh
@@ -3,17 +3,20 @@ INVENTORY="./.vagrant/provisioners/ansible/inventory"
 PLAYBOOKS="./provision/prepare-guests.yml"
 
 if [[ "x$1" == "x-h" || "x$1" == "x--help" ]]; then
-    echo "provision.sh [LIMIT SKIP_PACKAGES PLAYBOOKS]"
+    echo "provision.sh [DIST LIMIT SKIP_PACKAGES PLAYBOOKS DIST]"
+    echo "  DIST: [fedora|suse] ... Define what distribution will be used for the client"
     echo "  LIMIT: [all|list of host] ... limit which hosts should be provisioned"
     echo "  SKIP_PACKAGES: [true|false] ... skip package installation"
     echo "  PLAYBOOKS: [playbook paths] ... playbooks to run"
     echo ""
     exit 0
 fi
+DIST=${1-"fedora"}
+LIMIT=${2-all}
+SKIP_PACKAGES=${3-true}
+PLAYBOOKS=${4-$PLAYBOOKS}
 
-LIMIT=${1-all}
-SKIP_PACKAGES=${2-true}
-PLAYBOOKS=${3-$PLAYBOOKS}
+echo "Linux distro used for the client: $DIST"
 
 run-playbook() {
     local PLAYBOOK=$1
@@ -21,9 +24,9 @@ run-playbook() {
     echo "Executing playbook $PLAYBOOK"
 
     ANSIBLE_HOST_KEY_CHECKING="false" ANSIBLE_SSH_ARGS="$SSH_ARGS" \
-    ansible-playbook                                               \
+    ansible-playbook -v                                               \
       --limit "$LIMIT"                                             \
-      --extra-vars="skip_packages=$SKIP_PACKAGES"                  \
+      --extra-vars="skip_packages=$SKIP_PACKAGES dist=$DIST"                  \
       --inventory-file="$INVENTORY"                                \
       $PLAYBOOK
 }

--- a/provision/install-packages-suse.sh
+++ b/provision/install-packages-suse.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+# Install packages directly through dnf than Ansible since
+# it seems to be faster and it can be run in parallel.
+
+HOST=${1-"UNKNOWN"}
+
+echo "Installing packages on host $HOST"
+
+echo "Updating installed packages"
+zypper --non-interactive update > /dev/null
+
+
+# Install packages required for Ansible operation and other common packages
+echo "Installing common packages"
+
+#libselinux-python       \
+
+zypper --non-interactive in \
+    bash-completion         \
+    dnsmasq                 \
+    gdb                     \
+    git                     \
+    ldb-tools               \
+    NetworkManager          \
+    openldap2-client        \
+    python                  \
+    python-dnf              \
+    python-ldap             \
+    tig                     \
+    vim                     \
+    wget                    \
+  > /dev/null
+
+echo "Installing host specific packages"
+
+if [ $HOST == "ipa" ]; then
+    zypper --non-interactive in     \
+        freeipa-server              \
+        freeipa-server-dns          \
+        freeipa-server-trust-ad     \
+      > /dev/null
+fi
+
+if [ $HOST == "ldap" ]; then
+    zypper --non-interactive in     \
+        389-ds-base                 \
+      > /dev/null
+fi
+
+if [ $HOST == "client" ]; then
+    # adcli                       \
+    # samba4-devel                \
+    # freeipa-client              \
+    # libnfsidmap-devel           \
+    # oddjob                      \
+    # oddjob-mkhomedir            \
+    # selinux-policy-targeted     \
+    zypper --non-interactive in     \
+        augeas-devel                \
+        autoconf                    \
+        automake                    \
+        bind-utils                  \
+        c-ares-devel                \
+        check                       \
+        check-devel                 \
+        cifs-utils-devel            \
+        dbus-1-devel                \
+        libdbus-1-3                 \
+        diffstat                    \
+        docbook-xsl-stylesheets     \
+        doxygen                     \
+        gettext                     \
+        gettext-devel               \
+        glib2-devel                 \
+        http-parser-devel           \
+        libjansson-devel            \
+        libkeyutils1                \
+        keyutils-devel              \
+        krb5-devel                  \
+        libcmocka0                  \
+        libcmocka-devel             \
+        libcollection-devel         \
+        libcurl-devel               \
+        libdhash-devel              \
+        libini_config-devel         \
+        libldb1                     \
+        libldb-devel                \
+        libnfsidmap-sss             \
+        libnl3-devel                \
+        libpath_utils-devel         \
+        libref_array-devel          \
+        libselinux-devel            \
+        libsemanage-devel           \
+        libsmbclient-devel          \
+        libtalloc2                  \
+        libtalloc-devel             \
+        libtdb1                     \
+        libtdb-devel                \
+        libtevent0                  \
+        libtevent-devel             \
+        libtool                     \
+        libuuid-devel               \
+        libxml2                     \
+        libxslt                     \
+        m4                          \
+        mozilla-nspr-devel          \
+        mozilla-nss-devel           \
+        mozilla-nss-tools           \
+        nss_wrapper                 \
+        openldap2-devel             \
+        pam-devel                   \
+        pam_wrapper                 \
+        pcre-devel                  \
+        pkgconfig                   \
+        po4a                        \
+        popt-devel                  \
+        python-devel                \
+        python3-devel               \
+        realmd                      \
+        resolv_wrapper              \
+        samba-client                \
+        samba-core-devel            \
+        libsamba-credentials-devel  \
+        libsamba-errors-devel       \
+        libsamba-hostconfig-devel   \
+        libsamba-passdb-devel       \
+        libsamba-policy-devel       \
+        libsamba-util-devel         \
+        socket_wrapper              \
+        sssd                        \
+        sssd-*                      \
+        systemd-devel               \
+        systemtap-sdt-devel         \
+        uid_wrapper                 \
+        krb5-client                 \
+      > /dev/null
+        
+    zypper --non-interactive in     \
+        dbus-1-devel                \
+        libcmocka0                  \
+        libcollection-devel         \
+        libdhash1                   \
+        libini_config5              \
+        libldb1                     \
+        libtalloc2                  \
+        libtevent0                  \
+      > /dev/null
+fi

--- a/provision/roles/common/tasks/main.yml
+++ b/provision/roles/common/tasks/main.yml
@@ -32,6 +32,7 @@
   selinux:
     policy: targeted
     state: permissive
+  when: dist is not defined or dist != "suse"
 
 - name: 'Create /shared/enrollment/{{ inventory_hostname }} directory'
   become: True

--- a/provision/roles/dnsclient/tasks/main.yml
+++ b/provision/roles/dnsclient/tasks/main.yml
@@ -6,6 +6,7 @@
     owner: root
     group: root
     mode: 0644
+  when: dist is not defined or dist != "suse"  
 
 - name: Create /etc/NetworkManager/dnsmasq.d/zone_vm.dnsmasq
   become: True
@@ -16,6 +17,21 @@
     group: root
     mode: 0644
   register: result
+  when: dist is not defined or dist != "suse"
+
+- name: Create /etc/sysconfig/network/config (SUSE)
+  become: True
+  template:
+    src: suse.network.config
+    dest: /etc/sysconfig/network/config
+    owner: root
+    group: root
+    mode: 0644
+  register: result
+  when: 
+    - dist == "suse"
+    - "'client' in inventory_hostname"
+
 
 - name: Reload NetworkManager
   become: True
@@ -23,4 +39,13 @@
     name: NetworkManager.service
     enabled: yes
     state: reloaded
-  when: result.changed
+  when: result.changed and dist is not defined
+
+- name: Reload network.service (SUSE)
+  become: True
+  service:
+    name: network.service
+    enabled: yes
+    state: reloaded
+  when: result.changed and dist == "suse"
+

--- a/provision/roles/dnsclient/templates/suse.network.config
+++ b/provision/roles/dnsclient/templates/suse.network.config
@@ -1,0 +1,302 @@
+## Type:        integer
+## Default:     ""
+#
+# How log to wait for IPv6 autoconfig in ifup when requested with
+# the auto6 or +auto6 tag in BOOTPROTO variable.
+# When unset, a wicked built-in default defer time (10sec) is used.
+#
+AUTO6_WAIT_AT_BOOT=""
+
+## Type:        list(all,dns,none,"")
+## Default:     ""
+#
+# Whether to update system (DNS) settings from IPv6 RA when requested
+# with the auto6 or +auto6 tag in BOOTPROTO variable.
+# Defaults to update if autoconf sysctl (address autoconf) is enabled.
+#
+AUTO6_UPDATE=""
+
+## Type:        list(auto,yes,no)
+## Default:     "auto"
+#
+# Permits to specify/modify a global ifcfg default. Use with care!
+#
+# This settings breaks rules for many things, which require carrier
+# before they can start, e.g. L2 link protocols, link authentication,
+# ipv4 duplicate address detection, ipv6 duplicate detection will
+# happen "post-mortem" and maybe even cause to disable ipv6 at all.
+# See also "man ifcfg" for further informations.
+#
+LINK_REQUIRED="auto"
+
+## Type:        string
+## Default:     ""
+#
+# Allows to specify a comma separated list of debug facilities used
+# by wicked. Negated facility names can be prepended by a "-", e.g.:
+#   "all,-events,-socket,-objectmodel,xpath,xml,dbus"
+#
+# When set, wicked debug level is automatically enabled.
+# For a complete list of facility names, see: "wicked --debug help".
+#
+WICKED_DEBUG=""
+
+## Type:        list("",error,warning,notice,info,debug,debug1,debug2,debug3)
+## Default:     ""
+#
+# Allows to specify wicked debug level. Default level is "notice".
+#
+WICKED_LOG_LEVEL=""
+## Path:	Network/General
+## Description:	Global network configuration
+#
+# Note: 
+# Most of the options can and should be overridden by per-interface
+# settings in the ifcfg-* files.
+#
+# Note: The ISC dhclient started by the NetworkManager is not using any
+# of these options -- NetworkManager is not using any sysconfig settings.
+#
+
+## Type:        yesno
+## Default:     yes
+# If ifup should check if an IPv4 address is already in use, set this to yes.
+#
+# Make sure that packet sockets (CONFIG_PACKET) are supported in the kernel,
+# since this feature uses arp, which depends on that.
+# Also be aware that this takes one second per interface; consider that when
+# setting up a lot of interfaces. 
+CHECK_DUPLICATE_IP="yes"
+
+## Type:        list(auto,yes,no)
+## Default:     auto
+# If ifup should send a gratuitous ARP to inform the receivers about its
+# IPv4 addresses. Default is to send gratuitous ARP, when duplicate IPv4
+# address check is enabled and the check were sucessful.
+#
+# Make sure that packet sockets (CONFIG_PACKET) are supported in the kernel,
+# since this feature uses arp, which depends on that.
+SEND_GRATUITOUS_ARP="auto"
+
+## Type:        yesno
+## Default:     no
+# Switch on/off debug messages for all network configuration stuff. If set to no
+# most scripts can enable it locally with "-o debug".
+DEBUG="no"
+
+## Type:	integer
+## Default:	30
+#
+# Some interfaces need some time to come up or come asynchronously via hotplug.
+# WAIT_FOR_INTERFACES is a global wait for all mandatory interfaces in
+# seconds. If empty no wait occurs.
+#
+WAIT_FOR_INTERFACES="30"
+
+## Type:	yesno
+## Default:	yes
+#
+# With this variable you can determine if the SuSEfirewall when enabled
+# should get started when network interfaces are started.
+FIREWALL="yes"
+
+## Type:	int
+## Default:	30
+#
+# When using NetworkManager you may define a timeout to wait for NetworkManager
+# to connect in NetworkManager-wait-online.service.  Other network services
+# may require the system to have a valid network setup in order to succeed.
+#
+# This variable has no effect if NetworkManager is disabled.
+#
+NM_ONLINE_TIMEOUT="30"
+
+## Type:        string
+## Default:     "dns-resolver dns-bind ntp-runtime nis"
+#
+# This variable defines the start order of netconfig modules installed
+# in the /etc/netconfig.d/ directory.
+#
+# To disable the execution of a module, don't remove it from the list
+# but prepend it with a minus sign, "-ntp-runtime".
+#
+NETCONFIG_MODULES_ORDER="dns-resolver dns-bind dns-dnsmasq nis ntp-runtime"
+
+## Type:        yesno
+## Default:     no
+#
+# Enable netconfig verbose reporting.
+#
+NETCONFIG_VERBOSE="no"
+
+## Type:	yesno
+## Default:	no
+#
+# This variable enables netconfig to always force a replace of modified
+# files and automatically enables the -f | --force-replace parameter.
+#
+# The purpose is to use it as workaround, when some other tool trashes
+# the files, e.g. /etc/resolv.conf and you observe messages like this
+# in your logs on in "netconfig update" output:
+# ATTENTION: You have modified /etc/resolv.conf. Leaving it untouched.
+#
+# Please do not forget to also report a bug as we have a system policy
+# to use netconfig.
+#
+NETCONFIG_FORCE_REPLACE="no"
+
+## Type:        string
+## Default:     "auto"
+#
+# Defines the DNS merge policy as documented in netconfig(8) manual page.
+# Set to "" to disable DNS configuration.
+#
+NETCONFIG_DNS_POLICY="STATIC"
+
+## Type:        string(resolver,bind,dnsmasq,)
+## Default:     "resolver"
+#
+# Defines the name of the DNS forwarder that has to be configured.
+# Currently implemented are "bind", "dnsmasq" and "resolver", that
+# causes to write the name server IP addresses to /etc/resolv.conf
+# only (no forwarder). Empty string defaults to "resolver".
+#
+NETCONFIG_DNS_FORWARDER="resolver"
+
+## Type:        yesno
+## Default:     yes
+#
+# When enabled (default) in forwarder mode ("bind", "dnsmasq"),
+# netconfig writes an explicit localhost nameserver address to the
+# /etc/resolv.conf, followed by the policy resolved name server list
+# as fallback for the moments, when the local forwarder is stopped.
+#
+NETCONFIG_DNS_FORWARDER_FALLBACK="yes"
+
+## Type:        string
+## Default:     ""
+#
+# List of DNS domain names used for host-name lookup.
+# It is written as search list into the /etc/resolv.conf file.
+#
+NETCONFIG_DNS_STATIC_SEARCHLIST="client.vm"
+
+## Type:        string
+## Default:     ""
+#
+# List of DNS nameserver IP addresses to use for host-name lookup.
+# When the NETCONFIG_DNS_FORWARDER variable is set to "resolver",
+# the name servers are written directly to /etc/resolv.conf.
+# Otherwise, the nameserver are written into a forwarder specific
+# configuration file and the /etc/resolv.conf does not contain any
+# nameservers causing the glibc to use the name server on the local
+# machine (the forwarder). See also netconfig(8) manual page.
+#
+NETCONFIG_DNS_STATIC_SERVERS="{{ vm_dns_server }}"
+
+## Type:        string
+## Default:     "auto"
+#
+# Allows to specify a custom DNS service ranking list, that is which
+# services provide preferred (e.g. vpn services), and which services
+# fallback settings (e.g. avahi).
+# Preferred service names have to be prepended with a "+", fallback
+# service names with a "-" character. The special default value
+# "auto" enables the current build-in service ranking list -- see the
+# netconfig(8) manual page -- "none" or "" disables the ranking.
+#
+NETCONFIG_DNS_RANKING="auto"
+
+## Type:        string
+## Default:     ""
+#
+# Allows to specify options to use when writting the /etc/resolv.conf,
+# for example:
+# 	"debug attempts:1 timeout:10"
+# See resolv.conf(5) manual page for details.
+#
+NETCONFIG_DNS_RESOLVER_OPTIONS=""
+
+## Type:        string
+## Default:     ""
+#
+# Allows to specify a sortlist to use when writting the /etc/resolv.conf,
+# for example:
+# 	130.155.160.0/255.255.240.0 130.155.0.0"
+# See resolv.conf(5) manual page for details.
+#
+NETCONFIG_DNS_RESOLVER_SORTLIST=""
+
+## Type:        string
+## Default:     "auto"
+#
+# Defines the NTP merge policy as documented in netconfig(8) manual page.
+# Set to "" to disable NTP configuration.
+#
+NETCONFIG_NTP_POLICY="auto"
+
+## Type:        string
+## Default:     ""
+#
+# List of NTP servers.
+#
+NETCONFIG_NTP_STATIC_SERVERS=""
+
+## Type:        string
+## Default:     "auto"
+#
+# Defines the NIS merge policy as documented in netconfig(8) manual page.
+# Set to "" to disable NIS configuration.
+#
+NETCONFIG_NIS_POLICY="auto"
+
+## Type:        string(yes,no,)
+## Default:     "yes"
+#
+# Defines whether to set the default NIS domain. When enabled and no domain
+# is provided dynamically or in static settings, /etc/defaultdomain is used.
+# Valid values are:
+#  - "no" or ""         netconfig does not set the domainname
+#  - "yes"              netconfig sets the domainname according to the
+#                       NIS policy using settings provided by the first
+#                       iterface and service that provided it.
+#  - "<interface name>" as yes, but only using settings from interface.
+#
+NETCONFIG_NIS_SETDOMAINNAME="yes"
+
+## Type:        string
+## Default:     ""
+#
+# Defines a default NIS domain.
+#
+# Further domain can be specified by adding a "_<number>" suffix to
+# the NETCONFIG_NIS_STATIC_DOMAIN and NETCONFIG_NIS_STATIC_SERVERS
+# variables, e.g.: NETCONFIG_NIS_STATIC_DOMAIN_1="second".
+#
+NETCONFIG_NIS_STATIC_DOMAIN=""
+
+## Type:        string
+## Default:     ""
+#
+# Defines a list of NIS servers for the default NIS domain or the
+# domain specified with same "_<number>" suffix.
+#
+NETCONFIG_NIS_STATIC_SERVERS=""
+
+## Type:	string
+## Default:	''
+#
+# Set this variable global variable to the ISO / IEC 3166 alpha2
+# country code specifying the wireless regulatory domain to set.
+# When not empty, ifup-wireless will be set in the wpa_supplicant
+# config or via 'iw reg set' command.
+#
+# Note: This option requires a wpa driver supporting it, like
+# the 'nl80211' driver used by default since openSUSE 11.3.
+# When you notice problems with your hardware, please file a
+# bug report and set e.g. WIRELESS_WPA_DRIVER='wext' (the old
+# default driver) in the ifcfg file.
+# See also "/usr/sbin/wpa_supplicant --help" for the list of
+# available wpa drivers.
+#
+WIRELESS_REGULATORY_DOMAIN=''

--- a/provision/roles/sssd/defaults/main.yml
+++ b/provision/roles/sssd/defaults/main.yml
@@ -9,3 +9,9 @@ ipa_domain: 'ipa.vm'
 
 # AD domain to which client will join
 ad_domain: 'ad.vm'
+
+# short domain
+ad_short_domain: 'ad'
+
+# AD Main server
+ad_main_server: 'root.ad.vm'

--- a/provision/roles/sssd/tasks/main.yml
+++ b/provision/roles/sssd/tasks/main.yml
@@ -106,14 +106,18 @@
   register: installed
   args:
     creates: /etc/ipa/ca.crt
+  when: dist is not defined or dist != "suse"  
 
 - name: Copy IPA keytab to local folder
   become: True
+  ignore_errors: yes
   copy:
     src: /etc/krb5.keytab
     dest: '/etc/sssd/ipa.keytab'
     remote_src: yes
-  when: installed.changed
+  when: 
+    - dist is not defined or dist != "suse"
+    - installed.changed
   
 - name: Remove /etc/krb5.keytab
   become: True
@@ -123,11 +127,14 @@
 
 - name: Copy IPA keytab to shared folder
   become: True
+  ignore_errors: yes
   copy:
     force: True
     src: /etc/sssd/ipa.keytab
     dest: '/shared/enrollment/{{ inventory_hostname }}/ipa.keytab'
     remote_src: yes
+  when: dist is not defined or dist != "suse"
+    
     
 - name: Join to Active Directory domain
   become: True
@@ -137,6 +144,62 @@
   register: installed
   args:
     creates: /etc/sssd/ad_enrolled
+  when: dist is not defined or dist != "suse"
+
+  # SUSE specific AD Join Steps
+- name: Create /etc/krb5.conf (SUSE)
+  become: True
+  template:
+    src: suse.krb5.conf
+    dest: /etc/krb5.conf
+    owner: root
+    group: root
+    mode: 0600
+  register: installed
+  when: dist == "suse"  
+
+- name: Create /etc/samba/smb.conf (SUSE)
+  become: True
+  template:
+    src: suse.smb.conf
+    dest: /etc/samba/smb.conf
+    owner: root
+    group: root
+    mode: 0600
+  register: installed
+  when: dist == "suse"  
+
+- name: Create /etc/nsswitch.conf (SUSE)
+  become: True
+  template:
+    src: suse.nsswitch.conf
+    dest: /etc/nsswitch.conf
+    owner: root
+    group: root
+    mode: 0600
+  register: installed
+  when: dist == "suse" 
+
+- name: Authenticate on the target domain using Kerberos (SUSE)
+  become: True
+  shell: |
+    echo vagrant | kinit Administrator
+    touch /etc/sssd/kinit_enrolled
+  register: installed
+  args:
+    creates: /etc/sssd/kinit_enrolled
+  when: dist is defined or dist == "suse"
+
+- name: Join to Active Directory domain using net command (SUSE)
+  become: True
+  shell: |
+    net ads join osname=”SLES” osVersion=15 osServicePack=”Latest” --no-dns-updates -k 
+    touch /etc/sssd/ad_suse_enrolled
+  register: installed
+  args:
+    creates: /etc/sssd/ad_suse_enrolled
+  when: dist is defined or dist == "suse"
+  
 
 - name: Copy AD keytab to local folder
   become: True
@@ -154,11 +217,23 @@
 
 - name: Copy AD keytab to shared folder
   become: True
+  ignore_errors: yes
   copy:
     force: True
     src: /etc/sssd/ad.keytab
     dest: '/shared/enrollment/{{ inventory_hostname }}/ad.keytab'
     remote_src: yes
+
+- name: Configure PAM to use sssd (SUSE)
+  become: True
+  shell: |
+    pam-config -–add -–sss
+    pam-config –-add –-mkhomedir 
+    touch /etc/sssd/pam_configured
+  register: installed
+  args:
+    creates: /etc/sssd/pam_configured
+  when: dist is defined or dist == "suse"
 
 - name: Create /etc/sssd/sssd.conf
   become: True
@@ -169,7 +244,19 @@
     group: root
     mode: 0600
   register: installed
-    
+  when: dist is not defined or dist != "suse"
+
+- name: Create /etc/sssd/sssd.conf (SUSE)
+  become: True
+  template:
+    src: suse.sssd.conf
+    dest: /etc/sssd/sssd.conf
+    owner: root
+    group: root
+    mode: 0600
+  register: installed
+  when: dist == "suse"  
+
 - name: Create /etc/sudo.conf
   become: True
   template:

--- a/provision/roles/sssd/templates/suse.krb5.conf
+++ b/provision/roles/sssd/templates/suse.krb5.conf
@@ -1,0 +1,28 @@
+[libdefaults]
+    # "dns_canonicalize_hostname" and "rdns" are better set to false for improved security.
+    # If set to true, the canonicalization mechanism performed by Kerberos client may
+    # allow service impersonification, the consequence is similar to conducting TLS certificate
+    # verification without checking host name.
+    # If left unspecified, the two parameters will have default value true, which is less secure.
+    dns_canonicalize_hostname = false
+    rdns = false
+    default_realm = {{ ad_domain|upper }}
+    default_ccache_name = /tmp/krb5cc_%{uid}
+
+[logging]
+    kdc = FILE:/var/log/krb5/krb5kdc.log
+    admin_server = FILE:/var/log/krb5/kadmind.log
+    default = SYSLOG:NOTICE:DAEMON
+
+[realms]
+
+    {{ ad_domain|upper }} = {
+      kdc = {{ ad_main_server }}
+      default_domain = {{ ad_domain }}
+      admin_server = {{ ad_main_server }}
+
+    }
+
+[domain_realm]
+  {{ ad_domain }} = {{ ad_domain|upper }}
+ .{{ ad_domain }} = {{ ad_domain|upper }}

--- a/provision/roles/sssd/templates/suse.nsswitch.conf
+++ b/provision/roles/sssd/templates/suse.nsswitch.conf
@@ -1,0 +1,44 @@
+#
+# /etc/nsswitch.conf
+#
+# An example Name Service Switch config file. This file should be
+# sorted with the most-used services at the beginning.
+#
+# The entry '[NOTFOUND=return]' means that the search for an
+# entry should stop if the search in the previous entry turned
+# up nothing. Note that if the search failed due to some other reason
+# (like no NIS server responding) then the search continues with the
+# next entry.
+#
+# Legal entries are:
+#
+#       compat                  Use compatibility setup
+#       nisplus                 Use NIS+ (NIS version 3)
+#       nis                     Use NIS (NIS version 2), also called YP
+#       dns                     Use DNS (Domain Name Service)
+#       files                   Use the local files
+#       [NOTFOUND=return]       Stop searching if not found so far
+#
+# For more information, please read the nsswitch.conf.5 manual page.
+#
+
+passwd:      sss files systemd
+shadow:     files sss
+group:       sss files systemd
+
+
+hosts:      files dns myhostname
+
+networks:	files dns
+
+services:	files sss
+protocols:	files
+rpc:		files
+ethers:		files
+netmasks:	files
+netgroup:	files sss nis 
+publickey:	files
+
+bootparams:	files
+automount:	files nis
+aliases:	files

--- a/provision/roles/sssd/templates/suse.smb.conf
+++ b/provision/roles/sssd/templates/suse.smb.conf
@@ -1,0 +1,59 @@
+# smb.conf is the main Samba configuration file. You find a full commented
+# version at /usr/share/doc/packages/samba/examples/smb.conf.SUSE if the
+# samba-doc package is installed.
+[global]
+	passdb backend = tdbsam
+	printing = cups
+	printcap name = cups
+	printcap cache time = 750
+	cups options = raw
+	map to guest = Bad User
+	include = /etc/samba/dhcp.conf
+	logon path = \\%L\profiles\.msprofile
+	logon home = \\%L\%U\.9xprofile
+	logon drive = P:
+	usershare allow guests = Yes
+    workgroup = AD
+    client signing = yes
+    client use spnego = yes
+    kerberos method = secrets and keytab
+    realm = {{ ad_domain|upper }}
+    security = ADS
+    create krb5 conf = no
+[homes]
+	comment = Home Directories
+	valid users = %S, %D%w%S
+	browseable = No
+	read only = No
+	inherit acls = Yes
+[profiles]
+	comment = Network Profiles Service
+	path = %H
+	read only = No
+	store dos attributes = Yes
+	create mask = 0600
+	directory mask = 0700
+[users]
+	comment = All users
+	path = /home
+	read only = No
+	inherit acls = Yes
+	veto files = /aquota.user/groups/shares/
+[groups]
+	comment = All groups
+	path = /home/groups
+	read only = No
+	inherit acls = Yes
+[printers]
+	comment = All Printers
+	path = /var/tmp
+	printable = Yes
+	create mask = 0600
+	browseable = No
+[print$]
+	comment = Printer Drivers
+	path = /var/lib/samba/drivers
+	write list = @ntadmin root
+	force group = ntadmin
+	create mask = 0664
+	directory mask = 0775

--- a/provision/roles/sssd/templates/suse.sssd.conf
+++ b/provision/roles/sssd/templates/suse.sssd.conf
@@ -1,0 +1,70 @@
+[sssd]
+config_file_version = 2
+services = nss, pam, sudo
+debug_level = 0x3ff0
+domains = AD, LDAP
+user = root
+
+[nss]
+debug_level = 0x3ff0
+timeout = 30000
+filter_users = root, vagrant
+filter_groups = root, vagrant
+# command = valgrind --leak-check=full --log-file=/tmp/valgrind.log /usr/libexec/sssd/sssd_nss --uid 0 --gid 0 -d 0x3ff0 --debug-to-files
+
+[pam]
+debug_level = 0x3ff0
+timeout = 30000
+
+[pac]
+debug_level = 0x3ff0
+timeout = 30000
+
+[sudo]
+debug_level = 0x3ff0
+timeout = 30000
+
+[ssh]
+debug_level = 0x3ff0
+timeout = 30000
+
+[ifp]
+debug_level = 0x3ff0
+timeout = 30000
+
+[kcm]
+debug_level = 0x3ff0
+timeout = 30000
+
+[secrets]
+debug_level = 0x3ff0
+timeout = 30000
+
+[domain/LDAP]
+id_provider = ldap
+ldap_uri = _srv_
+ldap_tls_reqcert = demand
+ldap_tls_cacert = /shared/enrollment/{{ ldap_host }}/cacert.asc
+dns_discovery_domain = {{ ldap_domain }}
+
+
+[domain/AD]
+id_provider = ad
+access_provider = ad
+ad_server = _srv_
+ad_domain = {{ ad_domain }}
+ipa_hostname = master.client.vm
+krb5_keytab = /shared/enrollment/{{ inventory_hostname }}/ad.keytab
+ldap_krb5_keytab = /shared/enrollment/{{ inventory_hostname }}/ad.keytab
+
+cache_credentials = true
+enumerate = false
+
+override_homedir = /home/%d/%u
+# dns_discovery_domain = {{ ad_domain }}
+# ad_server = _srv_, {{ ad_main_server }}
+
+# Enable to increase logging verbosity for troubleshooting domain connectivity
+debug_level = 7
+
+# Reference: https://www.suse.com/c/the-sssd-active-directory-and-sles-12-and-15/

--- a/setup.sh
+++ b/setup.sh
@@ -1,32 +1,48 @@
 #!/bin/bash
 
-echo "1. Preparing host..."
-ansible-playbook -i "localhost," -c local "./provision/prepare-host.yml"
+if [[ "x$1" == "x-h" || "x$1" == "x--help" ]]; then
+    echo "setup.sh [DIST HOST_EXEC]"
+    echo "  DIST: [fedora|suse] ... Define what distribution will be used for the client"
+    echo "  HOST_PREP: [true|false] ... Define if the playbook to prepare the host will run or not"
+    echo ""
+    exit 0
+fi
 
-if [ $? -ne 0 ]; then
-    echo "Unable to provision host machine!"
-    exit 1
+
+DIST=${1-"fedora"}
+HOST_PREP=${2-"true"}
+
+if [ "$HOST_PREP" == "true" ]; then
+    echo "1. Preparing host..."
+    ansible-playbook -i "localhost," -c local "./provision/prepare-host.yml"
+
+    if [ $? -ne 0 ]; then
+        echo "Unable to provision host machine!"
+        exit 1
+    fi
+else
+    echo "1. Skipping host preparation..."
 fi
 
 echo "2. Bringing up guests..."
 # Windows machines sometimes timeout when starting up in parallel
 # so we start them first in sequence.
 
-vagrant up ad
+DIST="$DIST" vagrant up ad
 
 if [ $? -ne 0 ]; then
     echo "Unable to bring ad up!"
     exit 1
 fi
 
-vagrant up ad-child
+DIST="$DIST" vagrant up ad-child
 
 if [ $? -ne 0 ]; then
     echo "Unable to bring ad-child up!"
     exit 1
 fi
 
-vagrant up
+DIST="$DIST" vagrant up
 
 if [ $? -ne 0 ]; then
     echo "Unable to bring guests up!"
@@ -34,7 +50,7 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "3. Provisioning guests..."
-./provision.sh
+./provision.sh "$DIST"
 
 if [ $? -ne 0 ]; then
     echo "Unable to provision guests!"


### PR DESCRIPTION
- Created an parameter to inform the Client Distro
 Informing the `distro = suse` will deploy the client machine using a
 openSUSE Leap 15 box and configure SSSD on it.
 The freeIPA integration will be skip as openSUSE does not provide
 freeIPA support.